### PR TITLE
Switch to S6 overlay and AdoptOpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,11 @@ RUN set -x \
     && echo 'dockremap:165536:65536' >> /etc/subuid \
     && echo 'dockremap:165536:65536' >> /etc/subgid
 
-ARG DIND_COMMIT=3b5fac462d21ca164b3778647420016315289034
-RUN wget -O /usr/local/bin/dind "https://raw.githubusercontent.com/docker/docker/${DIND_COMMIT}/hack/dind" \
-    && chmod +x /usr/local/bin/dind
+RUN set -eux; \
+    dind_commit=37498f009d8bf25fbb6199e8ccd34bed84f2874b; \
+    dind_file=/usr/local/bin/dind; \
+    wget -qO "$dind_file" "https://raw.githubusercontent.com/docker/docker/$dind_commit/hack/dind"; \
+    chmod +x "$dind_file"
 
 VOLUME /var/lib/docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,24 +13,26 @@ ARG gid=1000
 RUN groupadd -g ${gid} ${group}
 RUN useradd -c "Jenkins user" -d /home/${user} -u ${uid} -g ${gid} -m ${user}
 
-RUN apt-get update && \
-    # To get latest version of git
-    apt-get install -y software-properties-common && \
-    add-apt-repository -y ppa:git-core/ppa && \
-    apt-get update && \
-    apt-get install -qq \
-    git \
-    jq \
-    # Because of jenkins/slave
-    openjdk-8-jdk \
-    # Required to run Docker daemon in entrypoint
-    supervisor \
-    # Required to go back to jenkins user in entrypoint
-    gosu \
-    # Required to run Docker in Docker
-    iptables \
-    xz-utils \
-    btrfs-progs
+RUN set -exo pipefail; \
+    apt-get update; \
+    apt-get install -yq software-properties-common; \
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -; \
+    add-apt-repository -y ppa:git-core/ppa; \
+    add-apt-repository -y https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/; \
+    apt-get update; \
+    apt-get install -yq \
+        git \
+        jq \
+        # Because of jenkins/slave
+        adoptopenjdk-8-hotspot \
+        # Required to run Docker daemon in entrypoint
+        supervisor \
+        # Required to go back to jenkins user in entrypoint
+        gosu \
+        # Required to run Docker in Docker
+        iptables \
+        xz-utils \
+        btrfs-progs
 
 # Because of jenkins/slave
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-
-supervisord -c /etc/supervisor/conf.d/supervisord.conf
-
-exec gosu jenkins "$@"

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,0 @@
-[supervisord]
-user=root
-
-[program:dockerd]
-command=/usr/local/bin/dind dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375
-redirect_stderr=true
-stdout_logfile=/var/log/dind.log


### PR DESCRIPTION
## S6 Overlay
- The signals are properly handled
- Docker daemon starts on background
- CMD waits for the Docker daemon to be up before running
- Container exits when Docker daemon exits
## AdoptOpenJDK

The best OpenJDK distribution over there.